### PR TITLE
Overflow handling in `lin2vareq` and `affeq`

### DIFF
--- a/src/analyses/apron/relationAnalysis.apron.ml
+++ b/src/analyses/apron/relationAnalysis.apron.ml
@@ -174,7 +174,7 @@ struct
       Since affine equalities can only keep track of integer bounds of expressions evaluating to definite constants, we now query the integer bounds information for expressions from other analysis.
       If an analysis returns bounds that are unequal to min and max of ikind , we can exclude the possibility that an overflow occurs and the abstract effect of the expression assignment can be used, i.e. we do not have to set the variable's value to top. *)
 
-  let no_overflow (ask: Queries.ask) exp =
+  let no_overflow_not_constraint (ask: Queries.ask) exp =
     match Cilfacade.get_ikind_exp exp with
     | exception Invalid_argument _ -> false
     | exception Cilfacade.TypeOfError _ -> false
@@ -185,6 +185,14 @@ struct
         true
       else
         not (ask.f (MaySignedOverflow exp))
+
+  let rec no_overflow (ask: Queries.ask) exp =
+    match exp with
+    | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), e1, e2, _) ->
+      no_overflow_not_constraint ask e1 && no_overflow_not_constraint ask e2
+    | BinOp ((LAnd | LOr), e1, e2, _) -> no_overflow ask e1 && no_overflow ask e2
+    | UnOp (LNot,e,_) -> no_overflow ask e
+    | exp -> no_overflow_not_constraint ask exp
 
   let no_overflow ctx exp = lazy (
     let res = no_overflow ctx exp in

--- a/src/analyses/base.ml
+++ b/src/analyses/base.ml
@@ -1220,33 +1220,33 @@ struct
     match Cilfacade.get_ikind_exp exp with
     | exception _ -> BoolDomain.MayBool.top ()
     | ik ->
-      let r = match eval_rv_ask_evalint (Analyses.ask_of_ctx ctx) ctx.global ctx.local exp with
-        | Int i -> `Lifted i
-        | _   -> Queries.ID.top ()
-        | exception (IntDomain.ArithmeticOnIntegerBot _) -> Queries.ID.top () in
-      if Cil.isSigned ik && Queries.ID.is_top_of ik r then
-        true (** if EvalInt returns top, there was probably an overflow.
-                 Otherwise, to be sure that there is no overflow, we need to check each subexpression *)
-      else
-        match exp with
-        | Const _
-        | SizeOf _
-        | SizeOfStr _
-        | AlignOf _
-        | AddrOfLabel _ -> false
-        | Real e
-        | Imag e
-        | SizeOfE e
-        | AlignOfE e
-        | UnOp (_, e, _)
-        | CastE (_, e) -> exp_may_signed_overflow ctx e
-        | BinOp (_, e1, e2, _) ->
+      let exp_is_top = match eval_rv_ask_evalint (Analyses.ask_of_ctx ctx) ctx.global ctx.local exp with
+        | Int i ->Queries.ID.is_top_of ik (`Lifted i)
+        | _   -> true
+        | exception (IntDomain.ArithmeticOnIntegerBot _) -> true in
+      match exp with
+      | Const _
+      | SizeOf _
+      | SizeOfStr _
+      | AlignOf _
+      | AddrOfLabel _ -> false
+      | Real e
+      | Imag e
+      | SizeOfE e
+      | AlignOfE e
+      | CastE (_, e) -> exp_may_signed_overflow ctx e
+      | UnOp (_, e, _) ->
+        if Cil.isSigned ik && exp_is_top then true
+        (** if EvalInt returns top, there was probably an overflow.
+                Otherwise, to be sure that there is no overflow, we need to check each subexpression *)
+        else exp_may_signed_overflow ctx e
+      | BinOp (_, e1, e2, _) -> if Cil.isSigned ik && exp_is_top then true else
           exp_may_signed_overflow ctx e1 || exp_may_signed_overflow ctx e2
-        | Question (e1, e2, e3, _) ->
-          exp_may_signed_overflow ctx e1 || exp_may_signed_overflow ctx e2 || exp_may_signed_overflow ctx e3
-        | Lval lval
-        | AddrOf lval
-        | StartOf lval -> lval_may_signed_overflow ctx lval
+      | Question (e1, e2, e3, _) ->
+        exp_may_signed_overflow ctx e1 || exp_may_signed_overflow ctx e2 || exp_may_signed_overflow ctx e3
+      | Lval lval
+      | AddrOf lval
+      | StartOf lval -> lval_may_signed_overflow ctx lval
   and lval_may_signed_overflow ctx (lval : lval) =
     let (host, offset) = lval in
     let host_may_signed_overflow = function
@@ -1425,7 +1425,9 @@ struct
     | Q.InvariantGlobal g ->
       let g: V.t = Obj.obj g in
       query_invariant_global ctx g
-    | Q.MaySignedOverflow e -> exp_may_signed_overflow ctx e
+    | Q.MaySignedOverflow e -> (let res = exp_may_signed_overflow ctx e in
+                                if M.tracing then M.traceli "signed_overflow" "base exp_may_signed_overflow %a. Result = %b\n" d_plainexp e res; res
+                               )
     | _ -> Q.Result.top q
 
   let update_variable variable typ value cpa =

--- a/src/cdomains/apron/affineEqualityDomain.apron.ml
+++ b/src/cdomains/apron/affineEqualityDomain.apron.ml
@@ -115,42 +115,13 @@ struct
   let get_coeff_vec t texp = timing_wrap "coeff_vec" (get_coeff_vec t) texp
 end
 
-(** As it is specifically used for the new affine equality domain, it can only provide bounds if the expression contains known constants only and in that case, min and max are the same. *)
-module ExpressionBounds (Vc: AbstractVector) (Mx: AbstractMatrix): (SharedFunctions.ExtendedConvBounds with type t = VarManagement(Vc) (Mx).t) =
-struct
-  include VarManagement (Vc) (Mx)
-
-  let bound_texpr t texpr =
-    let texpr = Texpr1.to_expr texpr in
-    match Option.bind (get_coeff_vec t texpr) to_constant_opt with
-    | Some c when Mpqf.get_den c = IntOps.BigIntOps.one ->
-      let int_val = Mpqf.get_num c in
-      Some int_val, Some int_val
-    | _ -> None, None
-
-
-  let bound_texpr d texpr1 =
-    let res = bound_texpr d texpr1 in
-    (if M.tracing then
-       match res with
-       | Some min, Some max -> M.tracel "bounds" "min: %s max: %s" (IntOps.BigIntOps.to_string min) (IntOps.BigIntOps.to_string max)
-       | _ -> ()
-    );
-    res
-
-
-  let bound_texpr d texpr1 = timing_wrap "bounds calculation" (bound_texpr d) texpr1
-end
-
 module D(Vc: AbstractVector) (Mx: AbstractMatrix) =
 struct
   include Printable.Std
   include ConvenienceOps (Mpqf)
   include VarManagement (Vc) (Mx)
 
-  module Bounds = ExpressionBounds (Vc) (Mx)
-
-  module Convert = SharedFunctions.Convert (V) (Bounds) (struct let allow_global = true end) (SharedFunctions.Tracked)
+  module Convert = SharedFunctions.Convert (V) (struct let allow_global = true end) (SharedFunctions.Tracked)
 
   type var = V.t
 
@@ -204,6 +175,25 @@ struct
 
   let pretty () (x:t) = text (show x)
   let printXml f x = BatPrintf.fprintf f "<value>\n<map>\n<key>\nmatrix\n</key>\n<value>\n%s</value>\n<key>\nenv\n</key>\n<value>\n%s</value>\n</map>\n</value>\n" (XmlUtil.escape (Format.asprintf "%s" (show x) )) (XmlUtil.escape (Format.asprintf "%a" (Environment.print: Format.formatter -> Environment.t -> unit) (x.env)))
+
+  let eval_interval t texpr =
+    let texpr = Texpr1.to_expr texpr in
+    match Option.bind (get_coeff_vec t texpr) to_constant_opt with
+    | Some c when Mpqf.get_den c = IntOps.BigIntOps.one ->
+      let int_val = Mpqf.get_num c in
+      Some int_val, Some int_val
+    | _ -> None, None
+
+  let eval_interval d texpr1 =
+    let res = eval_interval d texpr1 in
+    (if M.tracing then
+       match res with
+       | Some min, Some max ->  if M.tracing then M.tracel "eval_interval" "min: %s max: %s" (IntOps.BigIntOps.to_string min) (IntOps.BigIntOps.to_string max);
+       | _ -> ()
+    );
+    res
+
+  let eval_interval d texpr1 = timing_wrap "eval_interval calculation" (eval_interval d) texpr1
 
   let name () = "affeq"
 
@@ -417,8 +407,7 @@ struct
 
   let assign_exp (t: VarManagement(Vc)(Mx).t) var exp (no_ov: bool Lazy.t) =
     let t = if not @@ Environment.mem_var t.env var then add_vars t [var] else t in
-    (* TODO: Do we need to do a constant folding here? It happens for texpr1_of_cil_exp *)
-    match Convert.texpr1_expr_of_cil_exp t t.env exp (Lazy.force no_ov) with
+    match Convert.texpr1_expr_of_cil_exp t t.env exp no_ov with
     | exp -> assign_texpr t var exp
     | exception Convert.Unsupported_CilExp _ ->
       if is_bot t then t else forget_vars t [var]
@@ -501,11 +490,10 @@ struct
 
   (** Assert a constraint expression.
 
-      Additionally, we now also refine after positive guards when overflows might occur and there is only one variable inside the expression and the expression is an equality constraint check (==).
-      We check after the refinement if the new value of the variable is outside its integer bounds and if that is the case, either revert to the old state or set it to bottom. *)
-
-
-  module BoundsCheck = SharedFunctions.BoundsCheckMeetTcons (Bounds) (V)
+      The overflow is completely handled by the flag "no_ov",
+      which is set in relationAnalysis.ml via the function no_overflow.
+      In case of a potential overflow, "no_ov" is set to false
+      and Convert.tcons1_of_cil_exp will raise the exception Unsupported_CilExp Overflow *)
 
   let meet_tcons t tcons expr =
     let check_const cmp c = if cmp c Mpqf.zero then bot_env else t in
@@ -513,39 +501,35 @@ struct
       (* Flip the sign of the const. val in coeff vec *)
       let coeff = Vector.nth e (Vector.length e - 1) in
       Vector.set_val_with e (Vector.length e - 1) (Mpqf.neg coeff);
-      let res =
-        if is_bot t then
-          bot ()
-        else
-          let opt_m = Matrix.rref_vec_with (Matrix.copy @@ Option.get t.d) e in
-          if Option.is_none opt_m then bot () else {d = opt_m; env = t.env}
-      in
-      BoundsCheck.meet_tcons_one_var_eq res expr
+      if is_bot t then
+        bot ()
+      else
+        let opt_m = Matrix.rref_vec_with (Matrix.copy @@ Option.get t.d) e in
+        if Option.is_none opt_m then bot () else {d = opt_m; env = t.env}
+
     in
-    try
-      match get_coeff_vec t (Texpr1.to_expr @@ Tcons1.get_texpr1 tcons) with
-      | Some v ->
-        begin match to_constant_opt v, Tcons1.get_typ tcons with
-          | Some c, DISEQ -> check_const (=:) c
-          | Some c, SUP -> check_const (<=:) c
-          | Some c, EQ -> check_const (<>:) c
-          | Some c, SUPEQ -> check_const (<:) c
-          | None, DISEQ
-          | None, SUP ->
-            if equal (meet_vec v) t then
-              bot_env
-            else
-              t
-          | None, EQ ->
-            let res = meet_vec v in
-            if is_bot res then
-              bot_env
-            else
-              res
-          | _ -> t
-        end
-      | None -> t
-    with BoundsCheck.NotRefinable -> t
+    match get_coeff_vec t (Texpr1.to_expr @@ Tcons1.get_texpr1 tcons) with
+    | Some v ->
+      begin match to_constant_opt v, Tcons1.get_typ tcons with
+        | Some c, DISEQ -> check_const (=:) c
+        | Some c, SUP -> check_const (<=:) c
+        | Some c, EQ -> check_const (<>:) c
+        | Some c, SUPEQ -> check_const (<:) c
+        | None, DISEQ
+        | None, SUP ->
+          if equal (meet_vec v) t then
+            bot_env
+          else
+            t
+        | None, EQ ->
+          let res = meet_vec v in
+          if is_bot res then
+            bot_env
+          else
+            res
+        | _ -> t
+      end
+    | None -> t
 
   let meet_tcons t tcons expr = timing_wrap "meet_tcons" (meet_tcons t tcons) expr
 
@@ -557,14 +541,13 @@ struct
     if M.tracing then M.tracel "ops" "unify: %s %s -> %s\n" (show a) (show b) (show res);
     res
 
-  let assert_cons d e negate no_ov =
-    let no_ov = Lazy.force no_ov in
-    if M.tracing then M.tracel "assert_cons" "assert_cons with expr: %a %b" d_exp e no_ov;
+  let assert_constraint d e negate no_ov =
+    if M.tracing then M.tracel "assert_constraint" "assert_constraint with expr: %a %b" d_exp e (Lazy.force no_ov);
     match Convert.tcons1_of_cil_exp d d.env e negate no_ov with
     | tcons1 -> meet_tcons d tcons1 e
     | exception Convert.Unsupported_CilExp _ -> d
 
-  let assert_cons d e negate no_ov = timing_wrap "assert_cons" (assert_cons d e negate) no_ov
+  let assert_constraint d e negate no_ov = timing_wrap "assert_constraint" (assert_constraint d e negate) no_ov
 
   let relift t = t
 
@@ -584,9 +567,9 @@ struct
 
   let cil_exp_of_lincons1 = Convert.cil_exp_of_lincons1
 
-  let env (t: Bounds.t) = t.env
+  let env t = t.env
 
-  type marshal = Bounds.t
+  type marshal = t
 
   let marshal t = t
 

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -144,7 +144,7 @@ sig
   val keep_filter_with : t -> (Var.t -> bool) -> unit
   val forget_vars_with : t -> Var.t list -> unit
   val assign_exp_with : t -> Var.t -> exp -> bool Lazy.t -> unit
-  val assign_exp_parallel_with : t -> (Var.t * exp) list -> bool -> unit (* TODO: why this one isn't lazy? *)
+  val assign_exp_parallel_with : t -> (Var.t * exp) list -> bool Lazy.t -> unit
   val assign_var_with : t -> Var.t -> Var.t -> unit
   val assign_var_parallel_with : t -> (Var.t * Var.t) list -> unit
   val substitute_exp_with : t -> Var.t -> exp -> bool Lazy.t-> unit
@@ -235,8 +235,7 @@ end
 module AOps0 (Tracked: Tracked) (Man: Manager) =
 struct
   open SharedFunctions
-  module Bounds = Bounds (Man)
-  module Convert = Convert (V) (Bounds) (struct let allow_global = false end) (Tracked)
+  module Convert = Convert (V) (struct let allow_global = false end) (Tracked)
 
   type t = Man.mt A.t
 
@@ -280,7 +279,7 @@ struct
     A.forget_array_with Man.mgr nd vs' false
 
   let assign_exp_with nd v e no_ov =
-    match Convert.texpr1_of_cil_exp nd (A.env nd) e (Lazy.force no_ov) with
+    match Convert.texpr1_of_cil_exp nd (A.env nd) e no_ov with
     | texpr1 ->
       if M.tracing then M.trace "apron" "assign_exp converted: %s\n" (Format.asprintf "%a" Texpr1.print texpr1);
       A.assign_texpr_with Man.mgr nd v texpr1 None
@@ -347,7 +346,7 @@ struct
     A.assign_texpr_array Man.mgr d vs texpr1s None
 
   let substitute_exp_with nd v e no_ov =
-    match Convert.texpr1_of_cil_exp nd (A.env nd) e (Lazy.force no_ov) with
+    match Convert.texpr1_of_cil_exp nd (A.env nd) e no_ov with
     | texpr1 ->
       A.substitute_texpr_with Man.mgr nd v texpr1 None
     | exception Convert.Unsupported_CilExp _ ->
@@ -361,7 +360,7 @@ struct
       ves
       |> List.enum
       |> Enum.map (Tuple2.map2 (fun e ->
-          match Convert.texpr1_of_cil_exp nd env e (Lazy.force no_ov) with
+          match Convert.texpr1_of_cil_exp nd env e no_ov with
           | texpr1 -> Some texpr1
           | exception Convert.Unsupported_CilExp _ -> None
         ))
@@ -388,31 +387,10 @@ struct
     let texpr1 = Texpr1.of_expr (A.env nd) (Var v') in
     A.substitute_texpr_with Man.mgr nd v texpr1 None
 
-  (** Special affeq one variable logic to match AffineEqualityDomain. *)
-  let meet_tcons_affeq_one_var d res e =
-    let overflow_res res = if IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp e) then res else d in
-    match Convert.find_one_var e with
-    | None -> overflow_res res
-    | Some v ->
-      let ik = Cilfacade.get_ikind v.vtype in
-      match Bounds.bound_texpr res (Convert.texpr1_of_cil_exp res res.env (Lval (Cil.var v)) true) with
-      | Some _, Some _ when not (Cil.isSigned ik) -> d (* TODO: unsigned w/o bounds handled differently? *)
-      | Some min, Some max ->
-        assert (Z.equal min max); (* other bounds impossible in affeq *)
-        let (min_ik, max_ik) = IntDomain.Size.range ik in
-        if Z.compare min min_ik < 0 || Z.compare max max_ik > 0 then
-          if IntDomain.should_ignore_overflow ik then A.bottom (A.manager d) (A.env d) else d
-        else res
-      (* TODO: Unsupported_CilExp check? *)
-      | _, _ -> overflow_res res
-
   let meet_tcons d tcons1 e =
     let earray = Tcons1.array_make (A.env d) 1 in
     Tcons1.array_set earray 0 tcons1;
-    let res = A.meet_tcons_array Man.mgr d earray in
-    match Man.name () with
-    | "ApronAffEq" -> meet_tcons_affeq_one_var d res e (* TODO: don't hardcode by name, move to manager *)
-    | _ -> res
+    A.meet_tcons_array Man.mgr d earray
 
   let to_lincons_array d =
     A.to_lincons_array Man.mgr d
@@ -514,50 +492,53 @@ struct
   include AOps (Tracked) (Man)
   include Tracked
 
+  module Bounds = Bounds(Man)
+
+  let eval_interval = Bounds.bound_texpr
+
   (** Assert a constraint expression.
 
       LAnd, LOr, LNot are directly supported by Apron domain in order to
       confirm logic-containing Apron invariants from witness while deep-query is disabled *)
-  let rec assert_cons d e negate (ov: bool Lazy.t) =
-    let no_ov = IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp e) in (* TODO: why ignores no_ov argument? *)
+  let rec assert_constraint d e negate (no_ov: bool Lazy.t) =
     match e with
     (* Apron doesn't properly meet with DISEQ constraints: https://github.com/antoinemine/apron/issues/37.
        Join Gt and Lt versions instead. *)
     | BinOp (Ne, lhs, rhs, intType) when not negate ->
-      let assert_gt = assert_cons d (BinOp (Gt, lhs, rhs, intType)) negate ov in
-      let assert_lt = assert_cons d (BinOp (Lt, lhs, rhs, intType)) negate ov in
+      let assert_gt = assert_constraint d (BinOp (Gt, lhs, rhs, intType)) negate no_ov in
+      let assert_lt = assert_constraint d (BinOp (Lt, lhs, rhs, intType)) negate no_ov in
       join assert_gt assert_lt
     | BinOp (Eq, lhs, rhs, intType) when negate ->
-      let assert_gt = assert_cons d (BinOp (Gt, lhs, rhs, intType)) (not negate) ov in
-      let assert_lt = assert_cons d (BinOp (Lt, lhs, rhs, intType)) (not negate) ov in
+      let assert_gt = assert_constraint d (BinOp (Gt, lhs, rhs, intType)) (not negate) no_ov in
+      let assert_lt = assert_constraint d (BinOp (Lt, lhs, rhs, intType)) (not negate) no_ov in
       join assert_gt assert_lt
     | BinOp (LAnd, lhs, rhs, intType) when not negate ->
-      let assert_l = assert_cons d lhs negate ov in
-      let assert_r = assert_cons d rhs negate ov in
+      let assert_l = assert_constraint d lhs negate no_ov in
+      let assert_r = assert_constraint d rhs negate no_ov in
       meet assert_l assert_r
     | BinOp (LAnd, lhs, rhs, intType) when negate ->
-      let assert_l = assert_cons d lhs negate ov in
-      let assert_r = assert_cons d rhs negate ov in
+      let assert_l = assert_constraint d lhs negate no_ov in
+      let assert_r = assert_constraint d rhs negate no_ov in
       join assert_l assert_r (* de Morgan *)
     | BinOp (LOr, lhs, rhs, intType) when not negate ->
-      let assert_l = assert_cons d lhs negate ov in
-      let assert_r = assert_cons d rhs negate ov in
+      let assert_l = assert_constraint d lhs negate no_ov in
+      let assert_r = assert_constraint d rhs negate no_ov in
       join assert_l assert_r
     | BinOp (LOr, lhs, rhs, intType) when negate ->
-      let assert_l = assert_cons d lhs negate ov in
-      let assert_r = assert_cons d rhs negate ov in
+      let assert_l = assert_constraint d lhs negate no_ov in
+      let assert_r = assert_constraint d rhs negate no_ov in
       meet assert_l assert_r (* de Morgan *)
-    | UnOp (LNot,e,_) -> assert_cons d e (not negate) ov
+    | UnOp (LNot,e,_) -> assert_constraint d e (not negate) no_ov
     | _ ->
-      begin match Convert.tcons1_of_cil_exp d (A.env d) e negate no_ov with
+      begin match Convert.tcons1_of_cil_exp d (A.env d) e negate no_ov with (*TODO*)
         | tcons1 ->
-          if M.tracing then M.trace "apron" "assert_cons %a %s\n" d_exp e (Format.asprintf "%a" Tcons1.print tcons1);
-          if M.tracing then M.trace "apron" "assert_cons st: %a\n" D.pretty d;
+          if M.tracing then M.trace "apron" "assert_constraint %a %s\n" d_exp e (Format.asprintf "%a" Tcons1.print tcons1);
+          if M.tracing then M.trace "apron" "assert_constraint st: %a\n" D.pretty d;
           let r = meet_tcons d tcons1 e in
-          if M.tracing then M.trace "apron" "assert_cons r: %a\n" D.pretty r;
+          if M.tracing then M.trace "apron" "assert_constraint r: %a\n" D.pretty r;
           r
         | exception Convert.Unsupported_CilExp reason ->
-          if M.tracing then M.trace "apron" "assert_cons %a unsupported: %s\n" d_exp e (SharedFunctions.show_unsupported_cilExp reason);
+          if M.tracing then M.trace "apron" "assert_constraint %a unsupported: %s\n" d_exp e (SharedFunctions.show_unsupported_cilExp reason);
           d
       end
 
@@ -578,7 +559,7 @@ end
 module DHetero (Man: Manager): SLattice with type t = Man.mt A.t =
 struct
   include DBase (Man)
-
+  module Bounds = Bounds(Man)
 
 
   let gce (x: Environment.t) (y: Environment.t): Environment.t =
@@ -708,6 +689,21 @@ struct
     else
       false
 
+  let no_overflow_apron d env expr =
+    match Cilfacade.get_ikind_exp expr with
+    | ik ->
+      let (type_min, type_max) = IntDomain.Size.range ik in
+      let module Convert = SharedFunctions.Convert (V) (struct let allow_global = true end) (Tracked) in
+      let texpr = Convert.texpr1_of_cil_exp d env expr (Lazy.from_val true) in
+      begin match Bounds.bound_texpr d texpr with
+        | Some min, Some max when BI.compare type_min min <= 0 && BI.compare max type_max <= 0
+          -> true
+        | min_opt, max_opt ->
+          if M.tracing then M.trace "apron" "may overflow: %a (%a, %a)\n" CilType.Exp.pretty expr (Pretty.docOpt (IntDomain.BigInt.pretty ())) min_opt (Pretty.docOpt (IntDomain.BigInt.pretty ())) max_opt;
+          false end
+    | exception (Cilfacade.TypeOfError _)
+    | exception (Invalid_argument _) -> false
+
   let widen x y =
     let x_env = A.env x in
     let y_env = A.env y in
@@ -723,11 +719,12 @@ struct
         )
         else (
           let exps = ResettableLazy.force WideningThresholds.exps in
-          let module Convert = SharedFunctions.Convert (V) (Bounds(Man)) (struct let allow_global = true end) (Tracked) in
+          let module Convert = SharedFunctions.Convert (V) (struct let allow_global = true end) (Tracked) in
           (* this implements widening_threshold with Tcons1 instead of Lincons1 *)
           let tcons1s = List.filter_map (fun e ->
-              let no_ov = IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp e) in
-              match Convert.tcons1_of_cil_exp y y_env e false no_ov with
+              let no_overflow e = lazy(no_overflow_apron y y_env e)
+              in
+              match Convert.tcons1_of_cil_exp y y_env e false (no_overflow e) with
               | tcons1 when A.sat_tcons Man.mgr y tcons1 ->
                 Some tcons1
               | _

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -230,148 +230,13 @@ sig
   include AOpsPure with type t := t
 end
 
-
-(** Interface for Bounds which calculates bounds for expressions and is used inside the - Convert module. *)
-module type ConvBounds =
-sig
-  type t
-  val bound_texpr: t -> Texpr1.t -> Z.t option * Z.t option
-end
-
-(** Conversion from CIL expressions to Apron used by the apron domains*)
-module ApronOfCilForApronDomains (V: SV) (Bounds: ConvBounds) (Arg: ConvertArg) (Tracked: RelationDomain.Tracked) =
-struct
-  open Texpr1
-  open Tcons1
-
-  exception Unsupported_CilExp of unsupported_cilExp
-
-  let () = Printexc.register_printer (function
-      | Unsupported_CilExp reason -> Some (show_unsupported_cilExp reason)
-      | _ -> None (* for other exception *)
-    )
-
-  let texpr1_expr_of_cil_exp d env exp no_ov =
-    (* recurse without env argument *)
-    let rec texpr1_expr_of_cil_exp = function
-      | Lval (Var v, NoOffset) when Tracked.varinfo_tracked v ->
-        if not v.vglob || Arg.allow_global then
-          let var =
-            if v.vglob then
-              V.global v
-            else
-              V.local v
-          in
-          if Environment.mem_var env var then
-            Var var
-          else
-            raise (Unsupported_CilExp (Var_not_found v))
-        else
-          failwith "texpr1_expr_of_cil_exp: globals must be replaced with temporary locals"
-      | Const (CInt (i, _, _)) ->
-        Cst (Coeff.s_of_mpqf (Mpqf.of_mpz (Z_mlgmpidl.mpz_of_z i)))
-      | exp ->
-        match Cilfacade.get_ikind_exp exp with
-        | ik ->
-          let expr =
-            match exp with
-            | UnOp (Neg, e, _) ->
-              Unop (Neg, texpr1_expr_of_cil_exp e, Int, Near)
-            | BinOp (PlusA, e1, e2, _) ->
-              Binop (Add, texpr1_expr_of_cil_exp e1, texpr1_expr_of_cil_exp e2, Int, Near)
-            | BinOp (MinusA, e1, e2, _) ->
-              Binop (Sub, texpr1_expr_of_cil_exp e1, texpr1_expr_of_cil_exp e2, Int, Near)
-            | BinOp (Mult, e1, e2, _) ->
-              Binop (Mul, texpr1_expr_of_cil_exp e1, texpr1_expr_of_cil_exp e2, Int, Near)
-            | BinOp (Div, e1, e2, _) ->
-              Binop (Div, texpr1_expr_of_cil_exp e1, texpr1_expr_of_cil_exp e2, Int, Zero)
-            | BinOp (Mod, e1, e2, _) ->
-              Binop (Mod, texpr1_expr_of_cil_exp e1, texpr1_expr_of_cil_exp e2, Int, Near)
-            | CastE (TInt (t_ik, _) as t, e) ->
-              begin match IntDomain.should_ignore_overflow t_ik || IntDomain.Size.is_cast_injective ~from_type:(Cilfacade.typeOf e) ~to_type:t with (* TODO: unnecessary cast check due to overflow check below? or maybe useful in general to also assume type bounds based on argument types? *)
-                | true ->
-                  Unop (Cast, texpr1_expr_of_cil_exp e, Int, Zero) (* TODO: what does Apron Cast actually do? just for floating point and rounding? *)
-                | false
-                | exception Cilfacade.TypeOfError _ (* typeOf inner e, not outer exp *)
-                | exception Invalid_argument _ -> (* get_ikind in is_cast_injective *)
-                  raise (Unsupported_CilExp (Cast_not_injective t))
-              end
-            | _ ->
-              raise (Unsupported_CilExp Exp_not_supported)
-          in
-          if not no_ov then (
-            let (type_min, type_max) = IntDomain.Size.range ik in
-            let texpr1 = Texpr1.of_expr env expr in
-            match Bounds.bound_texpr d texpr1 with
-            | Some min, Some max when BI.compare type_min min <= 0 && BI.compare max type_max <= 0 -> ()
-            | min_opt, max_opt ->
-              if M.tracing then M.trace "apron" "may overflow: %a (%a, %a)\n" CilType.Exp.pretty exp (Pretty.docOpt (IntDomain.BigInt.pretty ())) min_opt (Pretty.docOpt (IntDomain.BigInt.pretty ())) max_opt;
-              raise (Unsupported_CilExp Overflow)
-          );
-          expr
-        | exception (Cilfacade.TypeOfError _ as e)
-        | exception (Invalid_argument _ as e) ->
-          raise (Unsupported_CilExp (Exp_typeOf e))
-    in
-    texpr1_expr_of_cil_exp exp
-
-  let texpr1_of_cil_exp d env e no_ov =
-    let e = Cil.constFold false e in
-    Texpr1.of_expr env (texpr1_expr_of_cil_exp d env e no_ov)
-
-  let tcons1_of_cil_exp d env e negate no_ov =
-    let e = Cil.constFold false e in
-    let (texpr1_plus, texpr1_minus, typ) =
-      match e with
-      | BinOp (r, e1, e2, _) ->
-        let texpr1_1 = texpr1_expr_of_cil_exp d env e1 no_ov in
-        let texpr1_2 = texpr1_expr_of_cil_exp d env e2 no_ov in
-        (* Apron constraints always compare with 0 and only have comparisons one way *)
-        begin match r with
-          | Lt -> (texpr1_2, texpr1_1, SUP)   (* e1 < e2   ==>  e2 - e1 > 0  *)
-          | Gt -> (texpr1_1, texpr1_2, SUP)   (* e1 > e2   ==>  e1 - e2 > 0  *)
-          | Le -> (texpr1_2, texpr1_1, SUPEQ) (* e1 <= e2  ==>  e2 - e1 >= 0 *)
-          | Ge -> (texpr1_1, texpr1_2, SUPEQ) (* e1 >= e2  ==>  e1 - e2 >= 0 *)
-          | Eq -> (texpr1_1, texpr1_2, EQ)    (* e1 == e2  ==>  e1 - e2 == 0 *)
-          | Ne -> (texpr1_1, texpr1_2, DISEQ) (* e1 != e2  ==>  e1 - e2 != 0 *)
-          | _ -> raise (Unsupported_CilExp BinOp_not_supported)
-        end
-      | _ -> raise (Unsupported_CilExp Exp_not_supported)
-    in
-    let inverse_typ = function
-      | EQ -> DISEQ
-      | DISEQ -> EQ
-      | SUPEQ -> SUP
-      | SUP -> SUPEQ
-      | EQMOD _ -> failwith "tcons1_of_cil_exp: cannot invert EQMOD"
-    in
-    let (texpr1_plus, texpr1_minus, typ) =
-      if negate then
-        (texpr1_minus, texpr1_plus, inverse_typ typ)
-      else
-        (texpr1_plus, texpr1_minus, typ)
-    in
-    let texpr1' = Binop (Sub, texpr1_plus, texpr1_minus, Int, Near) in
-    Tcons1.make (Texpr1.of_expr env texpr1') typ
-
-  let find_one_var e =
-    Basetype.CilExp.get_vars e
-    |> List.filter Tracked.varinfo_tracked
-    |> function
-    | [v] -> Some v
-    | _ -> None
-end
-
 (** Convenience operations on A. *)
 module AOps0 (Tracked: Tracked) (Man: Manager) =
 struct
   open SharedFunctions
   module Bounds = Bounds (Man)
-  module Convert =
-  struct
-    include ApronOfCilForApronDomains (V) (Bounds) (struct let allow_global = false end) (Tracked)
-    include CilOfApron (V)
-  end
+  module Convert = Convert (V) (Bounds) (struct let allow_global = false end) (struct let do_overflow_check = true end) (Tracked)
+
 
 
   type t = Man.mt A.t
@@ -416,7 +281,7 @@ struct
     A.forget_array_with Man.mgr nd vs' false
 
   let assign_exp_with nd v e no_ov =
-    match Convert.texpr1_of_cil_exp nd (A.env nd) e (Lazy.force no_ov) with
+    match Convert.texpr1_of_cil_exp nd (A.env nd) e no_ov with
     | texpr1 ->
       if M.tracing then M.trace "apron" "assign_exp converted: %s\n" (Format.asprintf "%a" Texpr1.print texpr1);
       A.assign_texpr_with Man.mgr nd v texpr1 None
@@ -432,7 +297,7 @@ struct
       ves
       |> List.enum
       |> Enum.map (Tuple2.map2 (fun e ->
-          match Convert.texpr1_of_cil_exp nd env e no_ov with
+          match Convert.texpr1_of_cil_exp nd env e (Lazy.from_val no_ov) with
           | texpr1 -> Some texpr1
           | exception Convert.Unsupported_CilExp _ -> None
         ))
@@ -483,7 +348,7 @@ struct
     A.assign_texpr_array Man.mgr d vs texpr1s None
 
   let substitute_exp_with nd v e no_ov =
-    match Convert.texpr1_of_cil_exp nd (A.env nd) e (Lazy.force no_ov) with
+    match Convert.texpr1_of_cil_exp nd (A.env nd) e no_ov with
     | texpr1 ->
       A.substitute_texpr_with Man.mgr nd v texpr1 None
     | exception Convert.Unsupported_CilExp _ ->
@@ -497,7 +362,7 @@ struct
       ves
       |> List.enum
       |> Enum.map (Tuple2.map2 (fun e ->
-          match Convert.texpr1_of_cil_exp nd env e (Lazy.force no_ov) with
+          match Convert.texpr1_of_cil_exp nd env e no_ov with
           | texpr1 -> Some texpr1
           | exception Convert.Unsupported_CilExp _ -> None
         ))
@@ -524,31 +389,10 @@ struct
     let texpr1 = Texpr1.of_expr (A.env nd) (Var v') in
     A.substitute_texpr_with Man.mgr nd v texpr1 None
 
-  (** Special affeq one variable logic to match AffineEqualityDomain. *)
-  let meet_tcons_affeq_one_var d res e =
-    let overflow_res res = if IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp e) then res else d in
-    match Convert.find_one_var e with
-    | None -> overflow_res res
-    | Some v ->
-      let ik = Cilfacade.get_ikind v.vtype in
-      match Bounds.bound_texpr res (Convert.texpr1_of_cil_exp res res.env (Lval (Cil.var v)) true) with
-      | Some _, Some _ when not (Cil.isSigned ik) -> d (* TODO: unsigned w/o bounds handled differently? *)
-      | Some min, Some max ->
-        assert (Z.equal min max); (* other bounds impossible in affeq *)
-        let (min_ik, max_ik) = IntDomain.Size.range ik in
-        if Z.compare min min_ik < 0 || Z.compare max max_ik > 0 then
-          if IntDomain.should_ignore_overflow ik then A.bottom (A.manager d) (A.env d) else d
-        else res
-      (* TODO: Unsupported_CilExp check? *)
-      | _, _ -> overflow_res res
-
   let meet_tcons d tcons1 e =
     let earray = Tcons1.array_make (A.env d) 1 in
     Tcons1.array_set earray 0 tcons1;
-    let res = A.meet_tcons_array Man.mgr d earray in
-    match Man.name () with
-    | "ApronAffEq" -> meet_tcons_affeq_one_var d res e (* TODO: don't hardcode by name, move to manager *)
-    | _ -> res
+    A.meet_tcons_array Man.mgr d earray
 
   let to_lincons_array d =
     A.to_lincons_array Man.mgr d
@@ -655,6 +499,7 @@ struct
       LAnd, LOr, LNot are directly supported by Apron domain in order to
       confirm logic-containing Apron invariants from witness while deep-query is disabled *)
   let rec assert_constraint d e negate (ov: bool Lazy.t) =
+    if M.tracing then M.trace "assert_constraint_apron" "%a ;;; %a\n" d_exp e d_plainexp e;
     let no_ov = IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp e) in (* TODO: why ignores no_ov argument? *)
     match e with
     (* Apron doesn't properly meet with DISEQ constraints: https://github.com/antoinemine/apron/issues/37.
@@ -685,7 +530,7 @@ struct
       meet assert_l assert_r (* de Morgan *)
     | UnOp (LNot,e,_) -> assert_constraint d e (not negate) ov
     | _ ->
-      begin match Convert.tcons1_of_cil_exp d (A.env d) e negate no_ov with
+      begin match Convert.tcons1_of_cil_exp d (A.env d) e negate (Lazy.from_val no_ov) with
         | tcons1 ->
           if M.tracing then M.trace "apron" "assert_constraint %a %s\n" d_exp e (Format.asprintf "%a" Tcons1.print tcons1);
           if M.tracing then M.trace "apron" "assert_constraint st: %a\n" D.pretty d;
@@ -859,10 +704,10 @@ struct
         )
         else (
           let exps = ResettableLazy.force WideningThresholds.exps in
-          let module Convert = ApronOfCilForApronDomains (V) (Bounds(Man)) (struct let allow_global = true end) (Tracked) in
+          let module Convert = SharedFunctions.Convert (V) (Bounds(Man)) (struct let allow_global = true end) (struct let do_overflow_check = true end)(Tracked) in
           (* this implements widening_threshold with Tcons1 instead of Lincons1 *)
           let tcons1s = List.filter_map (fun e ->
-              let no_ov = IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp e) in
+              let no_ov = lazy(IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp e)) in
               match Convert.tcons1_of_cil_exp y y_env e false no_ov with
               | tcons1 when A.sat_tcons Man.mgr y tcons1 ->
                 Some tcons1
@@ -928,7 +773,7 @@ end
 module D (Man: Manager)=
 struct
   module DWO = DWithOps (Man) (DHetero (Man))
-  include SharedFunctions.AssertionModule (V) (DWO)
+  include SharedFunctions.AssertionModule (V) (DWO) (struct let do_overflow_check = true end)
   include DWO
   module Tracked = Tracked
   module Man = Man

--- a/src/cdomains/apron/linearTwoVarEqualityDomain.apron.ml
+++ b/src/cdomains/apron/linearTwoVarEqualityDomain.apron.ml
@@ -264,34 +264,13 @@ struct
 
 end
 
-module ExpressionBounds: (SharedFunctions.ExtendedConvBounds with type t = VarManagement.t) =
-struct
-  include VarManagement
-
-  let bound_texpr t texpr = let texpr = Texpr1.to_expr texpr in
-    match get_coeff t texpr with
-    | Some (None, offset) -> Some offset, Some offset
-    | _ -> None, None
-
-
-  let bound_texpr d texpr1 =
-    let res = bound_texpr d texpr1 in
-    match res with
-    | Some min, Some max ->  if M.tracing then M.tracel "bounds" "min: %s max: %s" (IntOps.BigIntOps.to_string min) (IntOps.BigIntOps.to_string max); res
-    | _ -> res
-
-  let bound_texpr d texpr1 = timing_wrap "bounds calculation" (bound_texpr d) texpr1
-end
-
 module D =
 struct
   include Printable.Std
   include ConvenienceOps (Mpqf)
   include VarManagement
 
-  module Bounds = ExpressionBounds
-
-  module Convert = SharedFunctions.Convert (V) (Bounds) (struct let allow_global = true end) (SharedFunctions.Tracked)
+  module Convert = SharedFunctions.Convert (V) (struct let allow_global = true end) (SharedFunctions.Tracked)
 
   type var = V.t
 
@@ -326,6 +305,20 @@ struct
 
   let pretty () (x:t) = text (show x)
   let printXml f x = BatPrintf.fprintf f "<value>\n<map>\n<key>\nequalities-array\n</key>\n<value>\n%s</value>\n<key>\nenv\n</key>\n<value>\n%s</value>\n</map>\n</value>\n" (XmlUtil.escape (Format.asprintf "%s" (show x) )) (XmlUtil.escape (Format.asprintf "%a" (Environment.print: Format.formatter -> Environment.t -> unit) (x.env)))
+
+
+  let eval_interval t texpr = let texpr = Texpr1.to_expr texpr in
+    match get_coeff t texpr with
+    | Some (None, offset) -> Some offset, Some offset
+    | _ -> None, None
+
+  let eval_interval d texpr1 =
+    let res = eval_interval d texpr1 in
+    match res with
+    | Some min, Some max ->  if M.tracing then M.tracel "eval_interval" "min: %s max: %s" (IntOps.BigIntOps.to_string min) (IntOps.BigIntOps.to_string max); res
+    | _ -> res
+
+  let eval_interval d texpr1 = timing_wrap "eval_interval calculation" (eval_interval d) texpr1
 
   exception Contradiction
 
@@ -508,8 +501,8 @@ struct
       -> Convert.texpr1_expr_of_cil_exp handles overflow *)
   let assign_exp (t: VarManagement.t) var exp (no_ov: bool Lazy.t) =
     let t = if not @@ Environment.mem_var t.env var then add_vars t [var] else t in
-    match Convert.texpr1_expr_of_cil_exp t t.env exp (Lazy.force no_ov) with
-    | exp -> assign_texpr t var exp
+    match Convert.texpr1_expr_of_cil_exp t t.env exp no_ov with
+    | texp -> assign_texpr t var texp
     | exception Convert.Unsupported_CilExp _ ->
       if is_bot_env t then t else forget_vars t [var]
 
@@ -596,9 +589,10 @@ struct
     List.fold_righti (fun i k result -> show_element i k ^ "\n" ^ result) l ""
 
   (** Assert a constraint expression.
-
-      Additionally, we now also refine after positive guards when overflows might occur and there is only one variable inside the expression and the expression is an equality constraint check (==).
-      We check after the refinement if the new value of the variable is outside its integer bounds and if that is the case, either revert to the old state or set it to bottom. *)
+      The overflow is completely handled by the flag "no_ov",
+      which is set in relationAnalysis.ml via the function no_overflow.
+      In case of a potential overflow, "no_ov" is set to false
+      and Convert.tcons1_of_cil_exp will raise the exception Unsupported_CilExp Overflow *)
 
   (* meet_tcons -> meet with guard in if statement
      texpr -> tree expr (right hand side of equality)
@@ -606,19 +600,13 @@ struct
      tcons -> tree constraint (expression < 0)
      -> does not have types (overflow is type dependent)
   *)
-  module BoundsCheck = SharedFunctions.BoundsCheckMeetTcons (Bounds) (V)
 
-  let meet_tcons t tcons original_expr =
+  let meet_tcons t tcons original_expr no_ov =
     (* The expression is evaluated using an array of coefficients. The first element of the array belongs to the constant followed by the coefficients of all variables
        depending on the result in the array after the evaluating including resolving the constraints in t.d the tcons can be evaluated and additional constraints can be added to t.d *)
     match t.d with
     | None -> bot_env
     | Some d ->
-      let overflow_handling res original_expr =
-        match BoundsCheck.meet_tcons_one_var_eq res original_expr with
-        | exception BoundsCheck.NotRefinable -> t
-        | res -> res
-      in
       let expr = Array.init (Environment.size t.env) (fun _ -> Z.zero) in
       let constant = ref (Z.zero) in
       if is_bot_env t then bot_env else
@@ -651,7 +639,7 @@ struct
             match Tcons1.get_typ tcons, c with
             | EQ, Some c ->
               let res = meet_with_one_conj t (fst var) (None, c)
-              in overflow_handling res original_expr
+              in res
             | _ -> t (*Not supported right now*)
           else if var_count = 2 then
             let get_vars i a l = if Z.equal a Z.zero then l else (i, a)::l in
@@ -668,7 +656,7 @@ struct
                 else if Z.equal a1 Z.(-one) && Z.equal a2 Z.one
                 then meet_with_one_conj t var1 (Some var2, !constant)
                 else t
-              in overflow_handling res original_expr
+              in res
             | _-> t (*Not supported right now*)
           else
             t (*For any other case we don't know if the (in-) equality is true or false or even possible therefore we just return t *)
@@ -694,14 +682,13 @@ struct
      e.g. an if statement is encountered in the C code.
 
   *)
-  let assert_cons d e negate no_ov =
-    let no_ov = Lazy.force no_ov in
-    if M.tracing then M.tracel "assert_cons" "assert_cons with expr: %a %b\n" d_exp e no_ov;
+  let assert_constraint d e negate (no_ov: bool Lazy.t) =
+    if M.tracing then M.tracel "assert_constraint" "assert_constraint with expr: %a %b\n" d_exp e (Lazy.force no_ov);
     match Convert.tcons1_of_cil_exp d d.env e negate no_ov with
-    | tcons1 -> meet_tcons d tcons1 e
+    | tcons1 -> meet_tcons d tcons1 e no_ov
     | exception Convert.Unsupported_CilExp _ -> d
 
-  let assert_cons d e negate no_ov = timing_wrap "assert_cons" (assert_cons d e negate) no_ov
+  let assert_constraint d e negate no_ov = timing_wrap "assert_constraint" (assert_constraint d e negate) no_ov
 
   let relift t = t
 
@@ -735,9 +722,9 @@ struct
 
   let cil_exp_of_lincons1 = Convert.cil_exp_of_lincons1
 
-  let env (t: Bounds.t) = t.env
+  let env t = t.env
 
-  type marshal = Bounds.t
+  type marshal = t
   (* marshal is not compatible with apron, therefore we don't have to implement it *)
   let marshal t = t
 

--- a/src/cdomains/apron/sharedFunctions.apron.ml
+++ b/src/cdomains/apron/sharedFunctions.apron.ml
@@ -57,15 +57,8 @@ type unsupported_cilExp =
   | BinOp_not_supported (** BinOp constructor not supported. *)
 [@@deriving show { with_path = false }]
 
-(** Interface for Bounds which calculates bounds for expressions and is used inside the - Convert module. *)
-module type ConvBounds =
-sig
-  type t
-  val bound_texpr: t -> Texpr1.t -> Z.t option * Z.t option
-end
-
 (** Conversion from CIL expressions to Apron. *)
-module ApronOfCil (V: SV) (Bounds: ConvBounds) (Arg: ConvertArg) (Tracked: RelationDomain.Tracked) =
+module ApronOfCil (V: SV) (Arg: ConvertArg) (Tracked: RelationDomain.Tracked) =
 struct
   open Texpr1
   open Tcons1
@@ -77,7 +70,7 @@ struct
       | _ -> None (* for other exception *)
     )
 
-  let texpr1_expr_of_cil_exp d env exp no_ov =
+  let texpr1_expr_of_cil_exp _ env exp _ =
     (* recurse without env argument *)
     let rec texpr1_expr_of_cil_exp = function
       | Lval (Var v, NoOffset) when Tracked.varinfo_tracked v ->
@@ -99,8 +92,7 @@ struct
       | exp ->
         match Cilfacade.get_ikind_exp exp with
         | ik ->
-          let expr =
-            match exp with
+          begin match exp with
             | UnOp (Neg, e, _) ->
               Unop (Neg, texpr1_expr_of_cil_exp e, Int, Near)
             | BinOp (PlusA, e1, e2, _) ->
@@ -123,26 +115,22 @@ struct
                   raise (Unsupported_CilExp (Cast_not_injective t))
               end
             | _ ->
-              raise (Unsupported_CilExp Exp_not_supported)
-          in
-          if not no_ov then (
-            let (type_min, type_max) = IntDomain.Size.range ik in
-            let texpr1 = Texpr1.of_expr env expr in
-            match Bounds.bound_texpr d texpr1 with
-            | Some min, Some max when BI.compare type_min min <= 0 && BI.compare max type_max <= 0 -> ()
-            | min_opt, max_opt ->
-              if M.tracing then M.trace "apron" "may overflow: %a (%a, %a)\n" CilType.Exp.pretty exp (Pretty.docOpt (IntDomain.BigInt.pretty ())) min_opt (Pretty.docOpt (IntDomain.BigInt.pretty ())) max_opt;
-              raise (Unsupported_CilExp Overflow)
-          );
-          expr
+              raise (Unsupported_CilExp Exp_not_supported) end
         | exception (Cilfacade.TypeOfError _ as e)
         | exception (Invalid_argument _ as e) ->
           raise (Unsupported_CilExp (Exp_typeOf e))
     in
     texpr1_expr_of_cil_exp exp
 
+  let texpr1_expr_of_cil_exp d env exp no_ov =
+    let exp = Cil.constFold false exp in
+    if not @@ IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp exp)
+    && not (Lazy.force no_ov) then
+      (raise (Unsupported_CilExp Overflow))
+    else
+      texpr1_expr_of_cil_exp d env exp no_ov
+
   let texpr1_of_cil_exp d env e no_ov =
-    let e = Cil.constFold false e in
     Texpr1.of_expr env (texpr1_expr_of_cil_exp d env e no_ov)
 
   let tcons1_of_cil_exp d env e negate no_ov =
@@ -249,9 +237,9 @@ struct
 end
 
 (** Conversion between CIL expressions and Apron. *)
-module Convert (V: SV) (Bounds: ConvBounds) (Arg: ConvertArg) (Tracked: RelationDomain.Tracked)=
+module Convert (V: SV) (Arg: ConvertArg) (Tracked: RelationDomain.Tracked)=
 struct
-  include ApronOfCil (V) (Bounds) (Arg) (Tracked)
+  include ApronOfCil (V) (Arg) (Tracked)
   include CilOfApron (V)
 end
 
@@ -366,18 +354,18 @@ end
 
 
 
-(** A more specific module type for RelationDomain.RelD2 with ConvBounds integrated and various apron elements.
+(** A more specific module type for RelationDomain.RelD2 with various apron elements.
     It is designed to be the interface for the D2 modules in affineEqualityDomain and apronDomain and serves as a functor argument for AssertionModule. *)
 module type AssertionRelS =
 sig
   type t
-  module Bounds: ConvBounds with type t = t
 
   val is_bot_env: t -> bool
 
   val env: t -> Environment.t
 
-  val assert_cons: t -> exp -> bool -> bool Lazy.t -> t
+  val assert_constraint: t -> exp -> bool -> bool Lazy.t -> t
+  val eval_interval : t -> Texpr1.t -> Z.t option * Z.t option
 end
 
 module Tracked: RelationDomain.Tracked =
@@ -401,28 +389,28 @@ struct
   type nonrec var = V.t
   module Tracked = Tracked
 
-  module Convert = Convert (V) (Bounds) (struct let allow_global = false end) (Tracked)
+  module Convert = Convert (V) (struct let allow_global = false end) (Tracked)
 
-  let rec exp_is_cons = function
+  let rec exp_is_constraint = function
     (* constraint *)
     | BinOp ((Lt | Gt | Le | Ge | Eq | Ne), _, _, _) -> true
-    | BinOp ((LAnd | LOr), e1, e2, _) -> exp_is_cons e1 && exp_is_cons e2
-    | UnOp (LNot,e,_) -> exp_is_cons e
+    | BinOp ((LAnd | LOr), e1, e2, _) -> exp_is_constraint e1 && exp_is_constraint e2
+    | UnOp (LNot,e,_) -> exp_is_constraint e
     (* expression *)
     | _ -> false
 
-  (* TODO: move logic-handling assert_cons from Apron back to here, after fixing affeq bot-bot join *)
+  (* TODO: move logic-handling assert_constraint from Apron back to here, after fixing affeq bot-bot join *)
 
   (** Assert any expression. *)
   let assert_inv d e negate no_ov =
     let e' =
-      if exp_is_cons e then
+      if exp_is_constraint e then
         e
       else
         (* convert non-constraint expression, such that we assert(e != 0) *)
         BinOp (Ne, e, zero, intType)
     in
-    assert_cons d e' negate no_ov
+    assert_constraint d e' negate no_ov
 
   let check_assert d e no_ov =
     if is_bot_env (assert_inv d e false no_ov) then
@@ -433,10 +421,10 @@ struct
       `Top
 
   (** Evaluate non-constraint expression as interval. *)
-  let eval_interval_expr d e =
-    match Convert.texpr1_of_cil_exp d (env d) e false with (* why implicit false no_ov false here? *)
+  let eval_interval_expr d e no_ov =
+    match Convert.texpr1_of_cil_exp d (env d) e no_ov with
     | texpr1 ->
-      Bounds.bound_texpr d texpr1
+      let c = eval_interval d texpr1 in c
     | exception Convert.Unsupported_CilExp _ ->
       (None, None)
 
@@ -448,14 +436,14 @@ struct
     | exception Invalid_argument _ ->
       ID.top () (* real top, not a top of any ikind because we don't even know the ikind *)
     | ik ->
-      if M.tracing then M.trace "relation" "eval_int: exp_is_cons %a = %B\n" d_plainexp e (exp_is_cons e);
-      if exp_is_cons e then
+      if M.tracing then M.trace "relation" "eval_int: exp_is_constraint %a = %B\n" d_plainexp e (exp_is_constraint e);
+      if exp_is_constraint e then
         match check_assert d e no_ov with
         | `True -> ID.of_bool ik true
         | `False -> ID.of_bool ik false
         | `Top -> ID.top_of ik
       else
-        match eval_interval_expr d e with
+        match eval_interval_expr d e no_ov with
         | (Some min, Some max) -> ID.of_interval ~suppress_ovwarn:true ik (min, max)
         | (Some min, None) -> ID.starting ~suppress_ovwarn:true ik min
         | (None, Some max) -> ID.ending ~suppress_ovwarn:true ik max
@@ -476,42 +464,4 @@ module Mpqf = struct
 
   let get_num x = Z_mlgmpidl.z_of_mpzf @@ Mpqf.get_num x
   let hash x = 31 * (Z.hash (get_den x)) + Z.hash (get_num x)
-end
-
-
-(** Overflow handling for meet_tcons in affineEqualityDomain and linearTwoVarEqualityDomain.
-
-    It refines after positive guards when overflows might occur and there is only one variable inside the expression and the expression is an equality constraint check (==).
-    We check after the refinement if the new value of the variable is outside its integer bounds and if that is the case, either raise the exception "NotRefinable" or set it to bottom. *)
-module type ExtendedConvBounds =
-sig
-  include ConvBounds
-  val get_env: t -> Environment.t
-  val bot : unit -> t
-end
-module BoundsCheckMeetTcons (Bounds: ExtendedConvBounds) (V: SV) = struct
-  exception NotRefinable
-  module Convert = Convert (V) (Bounds) (struct let allow_global = true end) (Tracked)
-
-  let meet_tcons_one_var_eq res expr =
-    let overflow_res res = if IntDomain.should_ignore_overflow (Cilfacade.get_ikind_exp expr) then res else raise NotRefinable in
-    match Convert.find_one_var expr with
-    | None -> overflow_res res
-    | Some v ->
-      let ik = Cilfacade.get_ikind v.vtype in
-      if not (Cil.isSigned ik) then
-        raise NotRefinable
-      else
-        match Bounds.bound_texpr res (Convert.texpr1_of_cil_exp res (Bounds.get_env res) (Lval (Cil.var v)) true) with
-        | Some min, Some max ->
-          assert (Z.equal min max); (* other bounds impossible in affeq *)
-          let (min_ik, max_ik) = IntDomain.Size.range ik in
-          if Z.lt min min_ik || Z.gt max max_ik then
-            if IntDomain.should_ignore_overflow ik then
-              Bounds.bot ()
-            else
-              raise NotRefinable
-          else res
-        | exception Convert.Unsupported_CilExp _
-        | _ -> overflow_res res
 end

--- a/src/cdomains/apron/sharedFunctions.apron.ml
+++ b/src/cdomains/apron/sharedFunctions.apron.ml
@@ -57,7 +57,11 @@ type unsupported_cilExp =
   | BinOp_not_supported (** BinOp constructor not supported. *)
 [@@deriving show { with_path = false }]
 
-(** Conversion from CIL expressions to Apron. *)
+(** Conversion from CIL expressions to Apron.
+    This is used by the domains "affine equalities" and "linear two variable equalities".
+    It also handles the overflow through the flag "no_ov".
+    For this reason it was divided from the Convert module for the pure apron domains "ApronOfCilForApronDomains",
+*)
 module ApronOfCil (V: SV) (Arg: ConvertArg) (Tracked: RelationDomain.Tracked) =
 struct
   open Texpr1

--- a/src/domains/queries.ml
+++ b/src/domains/queries.ml
@@ -126,6 +126,7 @@ type _ t =
   | MustTermAllLoops: MustBool.t t
   | IsEverMultiThreaded: MayBool.t t
   | TmpSpecial:  Mval.Exp.t -> ML.t t
+  | MaySignedOverflow: exp -> MayBool.t t
 
 type 'a result = 'a
 
@@ -195,6 +196,7 @@ struct
     | MustTermAllLoops -> (module MustBool)
     | IsEverMultiThreaded -> (module MayBool)
     | TmpSpecial _ -> (module ML)
+    | MaySignedOverflow  _ -> (module MayBool)
 
   (** Get bottom result for query. *)
   let bot (type a) (q: a t): a result =
@@ -263,6 +265,7 @@ struct
     | MustTermAllLoops -> MustBool.top ()
     | IsEverMultiThreaded -> MayBool.top ()
     | TmpSpecial _ -> ML.top ()
+    | MaySignedOverflow _ -> MayBool.top ()
 end
 
 (* The type any_query can't be directly defined in Any as t,
@@ -328,6 +331,7 @@ struct
     | Any IsEverMultiThreaded -> 55
     | Any (TmpSpecial _) -> 56
     | Any (IsAllocVar _) -> 57
+    | Any (MaySignedOverflow _) -> 58
 
   let rec compare a b =
     let r = Stdlib.compare (order a) (order b) in
@@ -422,6 +426,7 @@ struct
     | Any (MayBeModifiedSinceSetjmp e) -> JmpBufDomain.BufferEntry.hash e
     | Any (MustBeSingleThreaded {since_start}) -> Hashtbl.hash since_start
     | Any (TmpSpecial lv) -> Mval.Exp.hash lv
+    | Any (MaySignedOverflow e) -> CilType.Exp.hash e
     (* IterSysVars:                                                                    *)
     (*   - argument is a function and functions cannot be compared in any meaningful way. *)
     (*   - doesn't matter because IterSysVars is always queried from outside of the analysis, so MCP's query caching is not done for it. *)
@@ -484,6 +489,7 @@ struct
     | Any MustTermAllLoops -> Pretty.dprintf "MustTermAllLoops"
     | Any IsEverMultiThreaded -> Pretty.dprintf "IsEverMultiThreaded"
     | Any (TmpSpecial lv) -> Pretty.dprintf "TmpSpecial %a" Mval.Exp.pretty lv
+    | Any (MaySignedOverflow e) -> Pretty.dprintf "MaySignedOverflow %a" CilType.Exp.pretty e
 end
 
 let to_value_domain_ask (ask: ask) =

--- a/tests/regression/63-affeq/02-unsigned_guards.c
+++ b/tests/regression/63-affeq/02-unsigned_guards.c
@@ -11,8 +11,10 @@ int main(){
         __goblint_check(i == 3); // UNKNOWN!
     }
 
-    unsigned int i;
-    if (i - 2u == 4294967295u) {
+    unsigned int i2;
+    if (i2 - 2u == 4294967295u) {
+                printf("i2");
+                printf("%u\n", i2);
         __goblint_check (i == 4294967297); // FAIL!
     }
 
@@ -29,8 +31,8 @@ int main(){
         __goblint_check(1);
     }
 
-    unsigned int x = 8;
-    if (x == 8u) {
+    unsigned int x2 = 8;
+    if (x2 == 8u) {
         __goblint_check(1); // reachable
     }
     return 0;

--- a/tests/regression/77-lin2vareq/30-termination-overflow.c
+++ b/tests/regression/77-lin2vareq/30-termination-overflow.c
@@ -1,0 +1,13 @@
+// SKIP TERM PARAM: --set "ana.activated[+]" lin2vareq
+
+#include <stdio.h>
+
+int main() {
+  int i = 2147483647;
+  i++;
+  while (i <= 10) {
+    printf("%d\n", i);
+  }
+
+  return 0;
+}

--- a/tests/regression/77-lin2vareq/31-overflow-unknown.c
+++ b/tests/regression/77-lin2vareq/31-overflow-unknown.c
@@ -1,0 +1,19 @@
+// SKIP PARAM: --set ana.activated[+] lin2vareq
+#include <goblint.h>
+#include <limits.h>
+
+int main(void) {
+  int x = 10;
+
+  if (x + 2147483647 == 2147483657) {
+    return 0;
+  }
+
+  __goblint_check(1);
+
+  // Overflow
+  int c = 2147483647;
+  c = c + 1;
+
+  __goblint_check(c < 2147483647); // UNKNOWN!
+}


### PR DESCRIPTION
This pull request completely rewrites the overflow handling for the analyses `lin2vareq` and `affeq`. 

## Old overflow handling

Before, the oveflow handling happened in `texpr1_expr_of_cil_exp`, `meet_tcons_one_var_eq` and also in other places. This was not very maintainable and it was not completely sound. Now all of this is solely handled by the `no_ov` flag. 

## New overflow handling

A query `MaySignedOverflow` was added to `base.ml`. It checks for each subexpression if there is an overflow, and it returns `false` for unsigned subexpressions. It uses `EvalInt` to find out if there was an overflow or not.

This query is used by the function `no_overflow`, which sets the `no_ov` flag, which is used in `texpr1_expr_of_cil_exp`, where the overflow handling takes place.

## Overflow checking for Apron domains

The apron domains (e.g. `polyhedra`) are not compatible with the new overflow checking method. They handle overflow differently than `affeq` and they rely on the bounds check that was made in `texpr1_expr_of_cil_exp` before I removed it. 
They cannot rely only on the `no_ov` flag to calculate the overflow, partly because they also store inequalities and because 
the `MaySignedOverflow` query is not suitable for finding overflow for unsigned expressions. 
Therefore the old overflow check in `texpr1_expr_of_cil_exp` was kept as it is, and it can be turned on or off by a flag set in the module `OverflowCheck`. It is turned on for the `apron` domains and off for `affeq` and `lin2vareq`.

## Other changes

The function `assert_cons` was renames to `assert_constraint` for better readability. 

The calculation of the bounds of an expression was moved to a function `eval_interval`.